### PR TITLE
Make git strategy configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ For focused work on a specific task:
 /cece:autonomous [issue-ref]
 ```
 
-CeCe works independently (🔥) toward the goal, creating branches and PRs in its
-own fork. Provide an issue reference or describe the task to create one.
+CeCe works independently (🔥) toward the goal, creating branches and PRs per
+your configured git strategy. Provide an issue reference or describe the task
+to create one.
 
 Send `stop` to interrupt and return to chat mode.
 
@@ -87,7 +88,11 @@ Examples:
 **Transparency:** CeCe uses dedicated accounts and git identity. Actions are
 always identifiable as coming from an agent.
 
-**Fork workflow:** CeCe works in forks it owns, never pushing to repositories
-owned by others.
+**Configurable git strategy:** CeCe supports three push strategies configured
+per-project in `.claude/cece.local.md`:
+- **Fork**: Work in a fork owned by CeCe's account (recommended)
+- **Remote**: Push to an existing remote the user specifies
+- **Custom**: Follow user-provided instructions for complex workflows
 
-**Protected branches:** CeCe never commits to `main` or `master`.
+**Protected branches:** CeCe never commits to `main` or `master` in command
+modes.

--- a/plugins/cece/commands/autonomous.md
+++ b/plugins/cece/commands/autonomous.md
@@ -26,13 +26,13 @@ for permission. Execute freely.
 - Run tests
 - Create branches (per naming convention)
 - Commit to your branches
-- Push to your fork
+- Push per `## Git Strategy` in `cece.local.md`
 - Create/update PRs
 - Post issue comments
 
 **NEVER:**
 - Commit to `main` or `master`
-- Push to repositories you do not own
+- Push to unauthorized remotes
 - Close issues
 - Merge PRs
 
@@ -128,8 +128,10 @@ After user sign-off:
 Work through each planned PR:
 
 1. **Branch**: Create or checkout branch per naming convention in `cece.local.md`
-2. **Fork**: Check if your fork exists. If not, create it. Add your fork as a
-   remote if not already configured.
+2. **Git setup**: Read `## Git Strategy` from `cece.local.md` and prepare:
+   - **fork**: Create fork if needed, add as `cece` remote, verify access
+   - **remote**: Verify the specified remote is accessible
+   - **custom**: Execute any setup instructions provided
 3. **Implement**: Write code, commit freely
 4. **Test**: Run tests after changes
 5. **PR**: When a PR scope is complete:

--- a/plugins/cece/commands/setup.md
+++ b/plugins/cece/commands/setup.md
@@ -121,10 +121,11 @@ Inform the user they can re-invoke the command to resume.
 - Discard uncommitted changes without asking
 
 **ALWAYS:**
-- Work in a fork owned by your configured account (from `.claude/cece.local.md`)
+- Follow the git strategy specified in `.claude/cece.local.md`
 - Use your configured identity as author for every commit
 - Follow branch naming from `.claude/cece.local.md`
-- Check for uncommitted changes before any git operation; alert the user if changes exist that you did not make
+- Check for uncommitted changes before any git operation; alert the user if
+  changes exist that you did not make
 
 ### Commit Identity
 
@@ -146,36 +147,23 @@ git commit --author="$(git config cece.name) <$(git config cece.email)>" \
 - In command modes: commit freely
 - In chat mode: only on explicit user request
 
-### Remotes and Forks
+### Remotes and Pushing
 
-**ALWAYS:**
-- Work in a fork owned by your configured account (specified in `.claude/cece.local.md` as `gh: <account>`)
+The git strategy is configured in `.claude/cece.local.md` under `## Git Strategy`.
+Read that section to determine how to push changes.
 
-**NEVER:**
-- Push to repositories you do not own
+**Strategy types:**
 
-**Setup:**
-1. Fork the repository to your configured account
-2. Add your fork as a remote named `cece`
-3. Set your branch to track your fork, not upstream
+- **fork**: Create/use a fork under your configured account. Add as remote named
+  `cece`. Push to `cece` remote.
+- **remote**: Push to the specified existing remote (e.g., `origin`).
+- **custom**: Follow the free-form instructions provided.
 
-```bash
-# Fork and add as remote
-gh repo fork --remote-name=cece
+**Hard constraints (all strategies):**
 
-# Or manually
-git remote add cece https://github.com/your-account/repo.git
-
-# Always push to your fork
-git push cece branch-name
-```
-
-**Verification:**
-Before pushing, verify your remote points to your fork:
-```bash
-git remote get-url cece
-# Should show: https://github.com/your-account/repo.git
-```
+- NEVER push to a remote you are not authorized to use
+- NEVER push to `main` or `master` branches (in command modes)
+- ALWAYS verify the remote before pushing
 
 ### Commit History
 
@@ -275,11 +263,19 @@ Create `.claude/` directory if needed, then gather the following from the user:
 2. Commit message style (e.g., conventional commits, imperative mood)
 3. Upstream repository (full URL or `owner/repo`, e.g.,
    `github.com/user/project` or `gitlab.com/org/project`)
-4. Issue tracker location (full URL or `owner/repo` on the platform, e.g.,
+4. Git strategy — how CeCe should push changes. Present these options:
+   - **Fork** (recommended): Create/use a fork under your configured account.
+     Requires CLI credentials configured in Step 7.
+   - **Remote**: Push to an existing remote. Specify the remote name
+     (e.g., `origin`). Verify it exists with `git remote get-url <name>`.
+   - **Custom**: Provide free-form instructions (where to push, branch handling,
+     authentication).
+5. Issue tracker location (full URL or `owner/repo` on the platform, e.g.,
    `github.com/user/project`, `gitlab.com/org/project`, `linear.app/team/project`,
    or None)
-5. PR template or required sections (path or description, or None)
-6. CLI tools and account for each (e.g., `gh: cece-bot`)
+6. PR template or required sections (path or description, or None)
+7. CLI tools and account for each (e.g., `gh: cece-bot`) — required if git
+   strategy is "Fork"
 
 Generate `.claude/cece.local.md`:
 
@@ -291,6 +287,21 @@ Generate `.claude/cece.local.md`:
 Branch naming: <answer>
 Commit style: <answer>
 Upstream: <answer>
+
+## Git Strategy
+
+Strategy: <fork|remote|custom>
+
+<!-- Include ONE of the following based on strategy -->
+
+<!-- fork: -->
+Account: <tool>: <account>
+
+<!-- remote: -->
+Remote: <remote-name>
+
+<!-- custom: -->
+<Describe workflow: where to push, branch handling, auth method>
 
 ## Project Management
 
@@ -306,12 +317,14 @@ PR template: <answer>
 
 Read the file and check for:
 - `## Git` section with branch naming, commit style, and upstream
+- `## Git Strategy` section with strategy type (fork, remote, or custom)
 - `## Project Management` section with issue tracker
 - `## CLI Tools & Accounts` section
 
 For each missing section or incomplete value:
 1. List what is missing
-2. Gather the missing values from the user
+2. Gather the missing values from the user (present git strategy options as
+   described above)
 3. Update the file
 
 ## Step 5: Verify CLI tool authentication


### PR DESCRIPTION
## Summary

- Replace hardcoded fork-based workflow with configurable git strategy
- Add three options: Fork (recommended), Remote, Custom
- Update `/cece:setup` to gather git strategy during project configuration
- Update embedded rules template and autonomous mode to read from config

## Test plan

- [x] Manually tested `/cece:setup` flow
- [x] Verify existing projects can add `## Git Strategy` section
- [x] Test each strategy type (fork, remote, custom)