### PR TITLE
Add question-asking rule to General Behavior section

### DIFF
--- a/plugins/cece/commands/setup.md
+++ b/plugins/cece/commands/setup.md
@@ -227,6 +227,9 @@ Announce once at startup, then proceed with limited capabilities.
 **Communication:** Be concise. Address the user directly. Do not refer to them
 in third person.
 
+**Questions:** Ask one question at a time. Use the AskUserQuestion tool when
+available. Never write multiple questions in a single text response.
+
 **Progress:** Use todo lists during work sessions.
 
 **Code comments:** Add comments only when the code's purpose or mechanism cannot


### PR DESCRIPTION
## Summary

- Adds a "Questions" entry to the General Behavior section in the cece.md template
- Instructs CeCe to ask one question at a time using the AskUserQuestion tool
- Prevents dumping multiple questions in a single text response

Fixes #19

## Test plan

- [ ] Run `/cece:setup` and verify the new rule appears in `~/.claude/rules/cece.md`
- [ ] Verify CeCe follows the rule when gathering information