### PR TITLE
Add mdbook site structure with introduction and getting started chapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.local.md
 .claude
+docs/book/

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "CeCe Documentation"
+authors = ["CeCe Contributors"]
+language = "en"
+
+[build]
+build-dir = "book"
+
+[output.html]
+git-repository-url = "https://github.com/lthms/cece"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,5 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+- [Getting Started](./getting-started.md)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -1,0 +1,87 @@
+# Getting Started
+
+This guide walks you through installing CeCe and running your first commands.
+
+## Installation
+
+Install CeCe through Claude Code's plugin system:
+
+```
+claude plugins:install cece
+```
+
+## Setup
+
+Before using CeCe's full capabilities, run the setup wizard:
+
+```
+/cece:setup
+```
+
+The wizard does two things:
+
+1. **Initializes CeCe's core rules** in your global `~/.claude/` directory
+   (creates or updates `CLAUDE.md` and `rules/cece.md`)
+2. **Creates per-project configuration** in `.claude/cece.local.md` with:
+   - **Git identity**: CeCe's name and email for commits
+   - **Git strategy**: How CeCe pushes changes (fork, remote, or custom)
+   - **Project management**: Which issue tracker you use
+
+Run setup in each project where you want to use CeCe. The local configuration
+file is yours to edit if your settings change.
+
+## First Commands
+
+After setup, try these commands to see CeCe in action:
+
+### Chat Mode
+
+By default, CeCe operates in chat mode (indicated by 🐱). Ask questions, request
+code reviews, or discuss implementation approaches. CeCe assists while you
+drive.
+
+### Working on Issues
+
+CeCe uses a multi-phase workflow for issue-driven development:
+
+**1. Scope** — Create or refine an issue:
+
+```
+/cece:scope #42
+```
+
+CeCe enters scope mode (indicated by ✨) and helps you define what needs to be
+done, producing a clear Definition of Done.
+
+**2. Design** — Make architectural decisions:
+
+```
+/cece:design #42
+```
+
+CeCe enters design mode (indicated by 🧠) and works through technical approach,
+architectural decisions, and open questions.
+
+**3. Plan** — Break work into PRs:
+
+```
+/cece:plan #42
+```
+
+CeCe enters planning mode (indicated by 📋) and creates a concrete plan with
+test strategy and PR breakdown.
+
+**4. Progress** — Execute the plan:
+
+```
+/cece:progress #42
+```
+
+CeCe enters progress mode (indicated by 🔥) and executes autonomously, creating
+branches, writing code, running tests, and opening PRs. Type `stop` at any time
+to interrupt.
+
+## Interrupting Commands
+
+In any command mode, type `stop` to halt CeCe's work. CeCe saves progress and
+returns to chat mode, telling you what was saved and how to resume.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,42 @@
+# Introduction
+
+Think vim, but for AI. CeCe is a modal coding assistant built as a plugin for
+Claude Code.
+
+## The Core Idea
+
+CeCe has a **chat mode** for open-ended collaboration and **command modes** for
+focused, autonomous work. This isn't new—Cline has Plan/Act modes, Roo Code has
+five role-based modes, Cursor has layout modes. But CeCe's modes are different:
+they're workflow phases, not task types.
+
+In chat mode, you're in control. CeCe discusses, suggests, and implements
+alongside you. In command modes, CeCe takes the lead on a specific task—scoping
+an issue, designing an approach, planning PRs, or executing work—while you
+retain the ability to interrupt at any time.
+
+## Why Modes?
+
+Structured workflows help with complex tasks. CeCe's modal design
+is about enacting these workflows with simple slash commands. This brings:
+
+- **Clear boundaries**: You always know which mode you're in. Chat mode shows
+  a 🐱 indicator; command modes show their own indicators.
+- **Explicit transitions**: You enter command modes deliberately with slash
+  commands like `/cece:plan`. You exit by completing the task or typing `stop`.
+- **Predictable behavior**: Each command mode has defined permissions and
+  constraints. You know what CeCe can and cannot do.
+
+## What CeCe Explores
+
+CeCe isn't trying to be the most capable coding assistant. Instead, it explores
+a few ideas that may be worth considering:
+
+- **Modal behavior**: Separating open collaboration from focused execution
+- **Agent identity**: CeCe has its own git identity and accounts, making
+  agent-authored work transparent
+- **Fork-first workflow**: CeCe pushes to its own fork, keeping your branches
+  clean until you merge
+
+These ideas aren't unique to CeCe, but the combination creates a particular
+workflow worth trying.


### PR DESCRIPTION
## Summary

- Set up mdbook documentation site in `docs/` directory
- Add Introduction chapter explaining CeCe's modal model and what it explores
- Add Getting Started chapter covering installation, setup, and first commands
- Add `docs/book/` to `.gitignore` to exclude build output

Part of #26

## Test plan

- [x] `mdbook build docs/` succeeds locally
- [x] `mdbook serve docs/` renders correctly (manual check)