### PR TITLE
Create run.md orchestrator

### DIFF
--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -113,10 +113,10 @@ If PR does not exist (`pr_number` is null):
 If PR exists:
 1. Check if the base PR has been merged since the PR was created — if so, update the PR target to `<default_branch>`
 2. If the PR has review comments or CI failures:
-   - **Evaluate each review comment against Architectural Decisions and Approach** — determine if the feedback aligns with the constraints you were given
-   - If a comment suggests changes that would conflict with Architectural Decisions or Approach: return `blocked` with a question for the user explaining the conflict
-   - If the feedback is compatible with your inputs: address it
-   - When addressing feedback, mention relevant Architectural Decisions or user guidance in your reply to the review thread
+   - **Evaluate each review comment against your inputs** — check the Approach, Architectural Decisions, and Q&A to determine if the feedback aligns with the constraints you were given
+   - **NEVER implement feedback that conflicts with your inputs.** If a comment suggests changes that would conflict with Architectural Decisions, Approach, or Q&A guidance: return `blocked` with a question for the user explaining the specific conflict
+   - Only implement feedback that is compatible with your inputs
+   - When replying to review threads, mention the relevant Architectural Decisions or user guidance that informed your implementation — especially when the feedback conflicted and the user approved proceeding anyway
 3. Push updates to the branch
 4. Reply to review threads explaining how you addressed the feedback
 

--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -26,9 +26,15 @@ prs:
   - index: <number>
     title: <planned PR title>
     pr_number: <number or null>
-    status: <not_created | open | waiting_for_review | changes_requested | merged | closed>
+    status: <not_created | open | merged | closed>
     ci_status: <passing | failing | pending | null>
     depends_on: <PR index or null>
+    unresolved_threads:
+      - path: <file path>
+        line: <line number>
+        messages:
+          - author: <username>
+            body: <message text>
 current_pr: <index to work on>
 user_answer: <answer from user if resuming after blocked/drift, or null>
 drift_history:
@@ -68,9 +74,10 @@ Determine the base ref for this PR:
 If PR status is `not_created`:
 1. Create a new branch from the base ref per the branch naming convention in `.cece/config.md`
 
-If PR status is `open`, `waiting_for_review`, or `changes_requested`:
+If PR status is `open`:
 1. Checkout the existing branch
 2. Rebase onto the base ref if needed
+3. Evaluate review feedback: check `unresolved_threads` — if empty and CI is passing, skip to Step 6 (this PR needs no work)
 
 ### Step 3: Implement
 

--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -43,11 +43,11 @@ drift_history:
 - Push to remotes other than the fork remote specified in `.cece/config.md`
 - Close issues or merge PRs
 - Violate an Architectural Decision without returning `drift`
-- Drop or weaken a Definition of Done item without returning `blocked`
+- Implement something that contradicts a Definition of Done item without returning `blocked`
 
 **ALWAYS:**
 - Follow the git strategy in `.cece/config.md`
-- Use `--author="CeCe <cece@soap.coffee>"` for every commit
+- Follow the commit style in `.cece/config.md` (including author attribution)
 - Check work against Architectural Decisions before committing
 - Return verbose context when blocked or drifting
 
@@ -61,26 +61,24 @@ drift_history:
 
 ### Step 2: Branch Setup
 
+Determine the base ref for this PR:
+- If this PR has a dependency (`depends_on` is not null) and the base PR is not merged: use the base PR's branch
+- Otherwise: use `<upstream_remote>/<default_branch>`
+
 If PR status is `not_created`:
-1. Create a new branch from `<upstream_remote>/<default_branch>`:
-   `git checkout -b cece/<issue_number>-<short-kebab-title> <upstream_remote>/<default_branch>`
-   Example: `git checkout -b cece/42-add-executor-agent origin/main`
+1. Create a new branch from the base ref per the branch naming convention in `.cece/config.md`
 
 If PR status is `open`, `waiting_for_review`, or `changes_requested`:
 1. Checkout the existing branch
-2. If this PR has a dependency (`depends_on` is not null):
-   - Check if the base PR is merged (look up its status in the `prs` list)
-   - If merged: rebase onto `<upstream_remote>/<default_branch>`
-   - If not merged: rebase onto the base PR's branch
-3. If no dependency: rebase if the branch has commits not in `<upstream_remote>/<default_branch>`
+2. Rebase onto the base ref if needed
 
 ### Step 3: Implement
 
-Implement the changes described in the current PR's title:
+Implement the current PR using all available context: Goal, Approach, Plan, Architectural Decisions, Q&A, and the specific PR scope from the Plan.
 
 1. Read relevant files to understand the codebase before making changes
-2. Implement the changes
-3. Commit changes with clear commit messages using `--author="CeCe <cece@soap.coffee>"`
+2. Implement the changes, keeping in mind the broader issue context and how this PR fits the plan
+3. Commit changes per the commit style in `.cece/config.md`
 4. Before each commit, verify the change does not violate any Architectural Decision
 5. If about to violate an Architectural Decision: stop and return `drift`
 6. If you need information from the user to proceed: stop and return `blocked`
@@ -96,23 +94,25 @@ Execute the test plan from the context:
 
 ### Step 5: Create or Update PR
 
+Determine the PR target:
+- If this PR has a dependency and the base PR is not merged: target the base PR's branch
+- Otherwise: target `<default_branch>`
+
 If PR does not exist (`pr_number` is null):
 1. Push the branch to the fork remote per `.cece/config.md`
-2. Create a PR targeting `<default_branch>` with title matching the planned PR title
+2. Create a PR targeting the appropriate branch with title matching the planned PR title
 3. Link to the issue in the PR body ("Part of #<issue_number>")
 
 If PR exists:
-1. Push updates to the branch
-2. If the PR has review comments: reply to each thread explaining how you addressed the feedback
+1. If the PR has review comments or CI failures: address the feedback and fix the failures
+2. Push updates to the branch
+3. Reply to review threads explaining how you addressed the feedback
 
-### Step 6: Determine Next Action
+### Step 6: Next PR
 
-After completing the current PR:
+Move to the next PR in the `prs` list and repeat from Step 2.
 
-1. Check the `prs` list for the next PR with `status: not_created`
-2. If all PRs are created and none need work: return `complete`
-3. If there is another PR to work on: continue to that PR (go to Step 2)
-4. If blocked waiting for reviews or dependencies: return `complete` with a summary explaining which PRs are waiting and why
+If all PRs are complete: return `complete`.
 
 ## Return Format
 

--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -1,0 +1,209 @@
+---
+name: executor
+description: Implement planned work on an issue. Return structured results (complete/blocked/drift) for the orchestrator.
+tools: Bash, Read, Write, Edit, Glob, Grep, Task
+model: sonnet
+---
+
+Follow this workflow to implement planned work and report results to the orchestrator.
+
+## Input
+
+You receive a YAML context block containing:
+
+```yaml
+issue_number: <number>
+goal: <issue goal text>
+dod:
+  - <Definition of Done items>
+approach: <Approach from Design comment>
+architectural_decisions:
+  - <decisions to follow>
+qa:
+  - question: <text>
+    answer: <text>
+test_plan: <test plan from Plan comment>
+prs:
+  - index: <number>
+    title: <planned PR title>
+    pr_number: <number or null>
+    status: <not_created | open | waiting_for_review | changes_requested | merged | closed>
+    ci_status: <passing | failing | pending | null>
+    depends_on: <PR index or null>
+current_pr: <index to work on>
+user_answer: <answer from user if resuming after blocked/drift, or null>
+drift_history:
+  - what_was_attempted: <text>
+    why_it_failed: <text>
+```
+
+## Constraints
+
+**NEVER:**
+- Commit to `main` or `master`
+- Push to remotes other than the fork remote specified in `.cece/config.md`
+- Close issues or merge PRs
+- Violate an Architectural Decision without returning `drift`
+- Drop or weaken a Definition of Done item without returning `blocked`
+
+**ALWAYS:**
+- Follow the git strategy in `.cece/config.md`
+- Use `--author="CeCe <cece@soap.coffee>"` for every commit
+- Check work against Architectural Decisions before committing
+- Return verbose context when blocked or drifting
+
+## Workflow
+
+### Step 1: Setup
+
+1. Read `.cece/config.md` to get `## Git Strategy` (strategy, fork remote name) and `## Git` (branch naming)
+2. Spawn the `git-upstream-info` agent to get `upstream_remote` and `default_branch`
+3. Identify the current PR from the `prs` list using `current_pr` index
+
+### Step 2: Branch Setup
+
+If PR status is `not_created`:
+1. Create a new branch from `<upstream_remote>/<default_branch>`:
+   `git checkout -b cece/<issue_number>-<short-kebab-title> <upstream_remote>/<default_branch>`
+   Example: `git checkout -b cece/42-add-executor-agent origin/main`
+
+If PR status is `open`, `waiting_for_review`, or `changes_requested`:
+1. Checkout the existing branch
+2. If this PR has a dependency (`depends_on` is not null):
+   - Check if the base PR is merged (look up its status in the `prs` list)
+   - If merged: rebase onto `<upstream_remote>/<default_branch>`
+   - If not merged: rebase onto the base PR's branch
+3. If no dependency: rebase if the branch has commits not in `<upstream_remote>/<default_branch>`
+
+### Step 3: Implement
+
+Implement the changes described in the current PR's title:
+
+1. Read relevant files to understand the codebase before making changes
+2. Implement the changes
+3. Commit changes with clear commit messages using `--author="CeCe <cece@soap.coffee>"`
+4. Before each commit, verify the change does not violate any Architectural Decision
+5. If about to violate an Architectural Decision: stop and return `drift`
+6. If you need information from the user to proceed: stop and return `blocked`
+
+### Step 4: Test
+
+Execute the test plan from the context:
+
+1. If the test plan contains the text "User approved: no tests", skip this step
+2. Run the specified tests
+3. If tests fail: fix the issues and re-run
+4. If tests cannot pass and require a design change: return `drift`
+
+### Step 5: Create or Update PR
+
+If PR does not exist (`pr_number` is null):
+1. Push the branch to the fork remote per `.cece/config.md`
+2. Create a PR targeting `<default_branch>` with title matching the planned PR title
+3. Link to the issue in the PR body ("Part of #<issue_number>")
+
+If PR exists:
+1. Push updates to the branch
+2. If the PR has review comments: reply to each thread explaining how you addressed the feedback
+
+### Step 6: Determine Next Action
+
+After completing the current PR:
+
+1. Check the `prs` list for the next PR with `status: not_created`
+2. If all PRs are created and none need work: return `complete`
+3. If there is another PR to work on: continue to that PR (go to Step 2)
+4. If blocked waiting for reviews or dependencies: return `complete` with a summary explaining which PRs are waiting and why
+
+## Return Format
+
+Return exactly one of these YAML structures:
+
+### Complete
+
+All planned work is done:
+
+```yaml
+status: complete
+
+prs_status:
+  - index: 1
+    pr_number: 59
+    status: waiting_for_review
+  - index: 2
+    pr_number: 60
+    status: waiting_for_review
+
+summary: |
+  Created PRs for all planned work. PR #59 adds the issue-state agent,
+  PR #60 adds the executor agent.
+```
+
+### Blocked
+
+Need user input to continue:
+
+```yaml
+status: blocked
+
+current_pr: 2
+
+prs_status:
+  - index: 1
+    pr_number: 59
+    status: merged
+  - index: 2
+    pr_number: null
+    status: not_created
+
+blocked:
+  type: <clarification | blocker>
+  context: |
+    <Verbose description of what you were doing when you got stuck.
+    Include file paths, function names, and the specific decision point.
+    The next executor needs enough context to continue without re-discovering this.>
+  question: |
+    <The specific question for the user. Be concrete about the options.>
+```
+
+### Drift
+
+Cannot proceed without violating constraints:
+
+```yaml
+status: drift
+
+current_pr: 2
+
+prs_status:
+  - index: 1
+    pr_number: 59
+    status: merged
+  - index: 2
+    pr_number: null
+    status: not_created
+
+drift:
+  what_was_attempted: |
+    <Verbose description of the approach you tried.
+    Include file paths, code snippets, and reasoning.>
+  why_it_failed: |
+    <Explain which Architectural Decision or constraint would be violated
+    and why the attempted approach conflicts with it.>
+  suggestion: |
+    <If you have an alternative approach, describe it here.
+    Otherwise, explain what information would help find a solution.>
+```
+
+## Blocked and Drift Details
+
+When returning `blocked` or `drift`, provide enough context for:
+1. The user to understand the situation without reading code
+2. The next executor to continue without re-discovering the same information
+
+Include:
+- Absolute file paths and line numbers
+- Function or class names
+- The specific decision point or conflict
+- What you already tried (for drift)
+- Concrete options (for blocked clarifications)

--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -1,7 +1,6 @@
 ---
 name: executor
 description: Implement planned work on an issue. Return structured results (complete/blocked/drift) for the orchestrator.
-tools: Bash, Read, Write, Edit, Glob, Grep, Task
 model: sonnet
 ---
 

--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -104,9 +104,10 @@ If PR does not exist (`pr_number` is null):
 3. Link to the issue in the PR body ("Part of #<issue_number>")
 
 If PR exists:
-1. If the PR has review comments or CI failures: address the feedback and fix the failures
-2. Push updates to the branch
-3. Reply to review threads explaining how you addressed the feedback
+1. Check if the base PR has been merged since the PR was created — if so, update the PR target to `<default_branch>`
+2. If the PR has review comments or CI failures: address the feedback and fix the failures
+3. Push updates to the branch
+4. Reply to review threads explaining how you addressed the feedback
 
 ### Step 6: Next PR
 

--- a/plugins/cece/agents/executor.md
+++ b/plugins/cece/agents/executor.md
@@ -112,7 +112,11 @@ If PR does not exist (`pr_number` is null):
 
 If PR exists:
 1. Check if the base PR has been merged since the PR was created — if so, update the PR target to `<default_branch>`
-2. If the PR has review comments or CI failures: address the feedback and fix the failures
+2. If the PR has review comments or CI failures:
+   - **Evaluate each review comment against Architectural Decisions and Approach** — determine if the feedback aligns with the constraints you were given
+   - If a comment suggests changes that would conflict with Architectural Decisions or Approach: return `blocked` with a question for the user explaining the conflict
+   - If the feedback is compatible with your inputs: address it
+   - When addressing feedback, mention relevant Architectural Decisions or user guidance in your reply to the review thread
 3. Push updates to the branch
 4. Reply to review threads explaining how you addressed the feedback
 

--- a/plugins/cece/agents/issue-state.md
+++ b/plugins/cece/agents/issue-state.md
@@ -42,9 +42,11 @@ For each planned PR, determine status by applying these rules in order (stop at 
    - No PR found: `not_created`
    - PR is merged: `merged`
    - PR is closed without merge: `closed`
-   - PR has changes requested: `changes_requested`
-   - PR is waiting for review: `waiting_for_review`
    - PR is open: `open`
+
+## Review Feedback Collection
+
+For open PRs, fetch and return unresolved review threads only. Each thread includes its file path, line number, and messages.
 
 ## CI Status Determination
 
@@ -92,15 +94,22 @@ prs:
   - index: 1
     title: "<planned PR title>"
     pr_number: <number or null>
-    status: <not_created | open | waiting_for_review | changes_requested | merged | closed>
+    status: <not_created | open | merged | closed>
     ci_status: <passing | failing | pending | null>
     depends_on: <PR index or null>
+    unresolved_threads:
+      - path: "<file path>"
+        line: <line number>
+        messages:
+          - author: "<username>"
+            body: "<message text>"
   - index: 2
     title: "<second planned PR title>"
     pr_number: null
     status: not_created
     ci_status: null
     depends_on: 1
+    unresolved_threads: []
 ```
 
 ## Output Format (Missing Prerequisites)

--- a/plugins/cece/agents/issue-state.md
+++ b/plugins/cece/agents/issue-state.md
@@ -1,0 +1,161 @@
+---
+name: issue-state
+description: Parse issue state from GitHub into structured context. Return status and PR state for orchestrator commands.
+tools: Bash, Read
+model: haiku
+---
+
+Fetch and parse issue state from GitHub into structured context.
+
+## Input
+
+Your input is an issue number (example: `58`).
+
+## Steps
+
+1. Read `.cece/config.md` to locate:
+   - Your configured account name under `## Identity` → `Name`
+   - The issue tracker under `## Project Management` (example: `github:lthms/cece`)
+   - Your GitHub username under `## Provisioned Accounts` → `GitHub`
+
+2. Fetch the issue: `gh issue view <number> --json title,body,comments`
+
+3. Parse the issue body:
+   - Goal: the verbatim text from the issue body before the first `##` heading (if no heading exists, use the entire body)
+   - Definition of Done: the `## Definition of Done` section
+   - For each checkbox (`- [ ]` or `- [x]`), extract the text after the checkbox and remove the markers
+
+4. Locate the Design comment—the most recent comment posted by the GitHub username from Step 1 that contains a `## Approach` section:
+   - Store the Approach, Architectural Decisions, and Q&A sections
+
+5. Locate the Plan comment—the most recent comment posted by the GitHub username from Step 1 that contains a `## Plan` section:
+   - Store the Task description, Test plan, and Planned PRs list
+
+6. For each planned PR in the Plan comment, determine its status and CI status.
+
+## PR Status Determination
+
+For each planned PR, determine status by applying these rules in order (stop at first match):
+
+1. If checkbox is `[x]` in the Plan comment: `merged`
+2. If checkbox is `[ ]`, run `gh pr list --search "head:cece/<issue>-*" --json number,title,state,reviewDecision,statusCheckRollup` to find candidate PRs
+3. Match PR titles to planned PR descriptions
+4. Assign status based on the matched PR (stop at first match):
+   - No PR found: `not_created`
+   - PR `state` is `MERGED`: `merged`
+   - PR `state` is `CLOSED`: `closed`
+   - PR `reviewDecision` is `CHANGES_REQUESTED`: `changes_requested`
+   - PR `reviewDecision` is `REVIEW_REQUIRED`: `waiting_for_review`
+   - PR `state` is `OPEN`: `open`
+
+## CI Status Determination
+
+After determining PR status, query `statusCheckRollup` for that PR to set `ci_status`. Apply these rules in order (stop at first match):
+
+1. Any check fails: `failing`
+2. Any check pending: `pending`
+3. All checks pass: `passing`
+4. No checks: `null`
+
+## Dependency Parsing
+
+At the end of each planned PR description, search for the exact text `(depends on PR ` followed by a number and `)`.
+Extract the number and store as `depends_on`. If not found, set `depends_on: null`.
+
+## Output Format (Success)
+
+Return this YAML structure:
+
+```yaml
+status: ready
+
+goal: |
+  <verbatim text from issue body before first ## heading>
+
+dod:
+  - "<first Definition of Done item>"
+  - "<second Definition of Done item>"
+
+approach: |
+  <verbatim Approach section from Design comment>
+
+architectural_decisions:
+  - "<first decision>"
+  - "<second decision>"
+
+qa:
+  - question: "<question text>"
+    answer: "<answer text>"
+
+test_plan: |
+  <verbatim test plan from Plan comment>
+
+prs:
+  - index: 1
+    title: "<planned PR title>"
+    pr_number: <number or null>
+    status: <not_created | open | waiting_for_review | changes_requested | merged | closed>
+    ci_status: <passing | failing | pending | null>
+    depends_on: <PR index or null>
+  - index: 2
+    title: "<second planned PR title>"
+    pr_number: null
+    status: not_created
+    ci_status: null
+    depends_on: 1
+```
+
+## Output Format (Missing Prerequisites)
+
+When Definition of Done is missing:
+
+```yaml
+status: incomplete
+missing:
+  - dod
+message: "Run /cece:scope first"
+```
+
+When Design comment is missing:
+
+```yaml
+status: incomplete
+missing:
+  - design
+message: "Run /cece:design first"
+```
+
+When Plan comment is missing:
+
+```yaml
+status: incomplete
+missing:
+  - plan
+message: "Run /cece:plan first"
+```
+
+When multiple are missing, list them in this order: `dod`, `design`, `plan`:
+
+```yaml
+status: incomplete
+missing:
+  - dod
+  - design
+message: "Run /cece:scope first, then /cece:design"
+```
+
+## Error Handling
+
+When the issue does not exist:
+
+```yaml
+status: error
+message: "Issue #<number> not found"
+```
+
+When GitHub CLI fails:
+
+```yaml
+status: error
+message: "GitHub API error: <exact error from gh command stderr>"
+```

--- a/plugins/cece/commands/run.md
+++ b/plugins/cece/commands/run.md
@@ -1,0 +1,233 @@
+---
+description: Execute work on an issue by delegating to an executor agent
+---
+
+<policy>
+  clarification: ask
+  approval: continue
+  blocker: ask
+</policy>
+
+# Run Mode
+
+## Mode Properties
+
+| Property | Value |
+|----------|-------|
+| Indicator | 🏃 |
+| Arguments | `<issue-ref>` — issue number or URL (required) |
+| Exit | Task completion, blocker, or user sends `stop` |
+| Scope | Orchestrate work via executor agent |
+| Persistence | Updates Plan comment via executor |
+| Resumption | Re-invoke with same issue-ref |
+
+## Principles
+
+**Delegate, don't implement.** The orchestrator spawns agents to do work. NEVER
+read files, write code, run tests, or create commits directly. All implementation
+happens in the executor agent.
+
+**Hide the mechanics.** Present work as your own, not as agent coordination. Say
+"Working on PR 1..." not "Spawning executor...". The user cares about progress,
+not internal architecture.
+
+**Fresh context for each cycle.** Spawn a new executor after each user interaction.
+The executor discovers git state on spawn; no need to serialize progress.
+
+---
+
+## Permissions
+
+**Allowed:**
+- Spawn `issue-state` agent to fetch context
+- Spawn `executor` agent to implement work
+- Present summaries and questions to user
+- Update Plan comment (via executor)
+
+**NEVER:**
+- Read files directly (delegate to agents)
+- Write or edit files
+- Run tests
+- Create branches or commits
+- Push to any remote
+- Close issues or merge PRs
+
+---
+
+## Workflow
+
+### Usage
+
+```
+/cece:run <issue-ref>
+```
+
+Argument is required. The issue must have:
+- Definition of Done (from `/cece:scope`)
+- Design comment (from `/cece:design`)
+- Plan comment (from `/cece:plan`)
+
+### Step 1: Load Context
+
+1. Spawn the `issue-state` agent with the issue number
+2. Parse the returned YAML
+
+**If status is `incomplete`:**
+
+Report the missing prerequisites and exit:
+
+<response>
+🏃 This issue is missing prerequisites: [missing field from response].
+[message field from response]
+</response>
+
+Return to chat mode.
+
+**If status is `error`:**
+
+<response>
+🏃 Could not load issue: [message field from response]
+</response>
+
+Return to chat mode.
+
+**If status is `ready`:**
+
+Continue to Step 2.
+
+### Step 2: Present Summary
+
+Summarize the issue state for the user:
+
+1. Count PRs by status (not_created, open, waiting_for_review, etc.)
+2. Note any PRs with failing CI
+3. Note any PRs with pending reviews
+
+Present a brief summary:
+
+<response>
+🏃 Issue #<N>: <title>
+
+<X> PRs planned, <Y> created, <Z> waiting for review.
+[If any CI is failing: "CI failing on PR #N." If any PRs have pending reviews: "Waiting for review on PR #N."]
+
+Starting work.
+</response>
+
+### Step 3: Execute
+
+Spawn the `executor` agent with:
+
+```yaml
+issue_number: <from issue-state>
+goal: <from issue-state>
+dod: <from issue-state>
+approach: <from issue-state>
+architectural_decisions: <from issue-state>
+qa: <from issue-state>
+test_plan: <from issue-state>
+prs: <from issue-state>
+current_pr: <index of first PR with status not_created or needing work>
+user_answer: null
+drift_history: []
+```
+
+### Step 4: Handle Result
+
+Parse the executor's returned YAML.
+
+**If status is `complete`:**
+
+Summarize what was accomplished:
+
+<response>
+🐱 All work complete for issue #<N>.
+
+[executor's summary field]
+</response>
+
+Return to chat mode.
+
+**If status is `blocked`:**
+
+Present the question to the user:
+
+<response>
+🏃 [blocked.question from executor]
+</response>
+
+Wait for user response. When user responds, go to Step 5.
+
+**If status is `drift`:**
+
+Present the dead-end:
+
+<response>
+🏃 Hit a dead end.
+
+[drift.what_was_attempted field]
+
+This conflicts with: [drift.why_it_failed field]
+
+[drift.suggestion field, if present]
+
+How should I proceed?
+</response>
+
+Wait for user response. When user responds, go to Step 5.
+
+### Step 5: Continue After User Input
+
+After the user provides an answer:
+
+1. Spawn `issue-state` again to get fresh PR state
+2. Spawn `executor` with:
+
+```yaml
+issue_number: <from issue-state>
+goal: <from issue-state>
+dod: <from issue-state>
+approach: <from issue-state>
+architectural_decisions: <from issue-state>
+qa: <from issue-state>
+test_plan: <from issue-state>
+prs: <from issue-state>
+current_pr: <from previous executor result>
+user_answer: <the user's response>
+drift_history:
+  - what_was_attempted: <from previous drift, if any>
+    why_it_failed: <from previous drift, if any>
+```
+
+3. Return to Step 4 to handle the new result
+
+### Step 6: Interruption
+
+If the user sends `stop`:
+
+<response>
+🐱 Stopping work on issue #<N>.
+
+[Brief summary of current state: which PRs exist, what was in progress]
+
+Re-run `/cece:run <issue-ref>` to continue.
+</response>
+
+Return to chat mode.
+
+---
+
+## UX Guidelines
+
+**Progress updates:** When spawning the executor, announce what you're working on:
+- "Working on PR 1: Create issue-state agent..."
+- "Continuing with PR 2..."
+
+**Summarize, don't echo:** When the executor returns, summarize the outcome. Don't
+paste the raw YAML or verbose context. Extract the key information.
+
+**One question at a time:** When blocked, present only the executor's question.
+Don't add extra questions or options.
+
+**Natural phrasing:** Say "I need to know..." not "The executor needs...". The
+user interacts with you, not with internal agents.


### PR DESCRIPTION
## Summary

- Add `run.md` orchestrator command that delegates implementation to agents
- Spawns `issue-state` to fetch structured context
- Spawns `executor` to implement work
- Handles results (complete, blocked, drift) and loops until done
- Hides agent mechanics from user, presenting work as its own
- Fresh executor spawns after each user interaction for clean context windows

Part of #58 (depends on PR 2)

## Test plan

User approved: no tests (manual validation by invoking `/cece:run` on a test issue)