### PR TITLE
Add MCP server with signal_interaction tool

### DIFF
--- a/cmd/cece/main.go
+++ b/cmd/cece/main.go
@@ -34,6 +34,15 @@ type Plugin struct {
 func main() {
 	setupLogger()
 
+	// Handle mcp subcommand
+	if len(os.Args) > 1 && os.Args[1] == "mcp" {
+		if err := runMCPServer(); err != nil {
+			fmt.Fprintf(os.Stderr, "cece mcp: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "cece: %v\n", err)
 		os.Exit(1)
@@ -63,6 +72,11 @@ func run() error {
 	plugin, err := ensurePlugin()
 	if err != nil {
 		return fmt.Errorf("plugin check failed: %w", err)
+	}
+
+	// Ensure MCP server is configured
+	if err := ensureMCPServer(); err != nil {
+		return fmt.Errorf("MCP server check failed: %w", err)
 	}
 
 	// Read project config

--- a/cmd/cece/mcp.go
+++ b/cmd/cece/mcp.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type signalInteractionArgs struct {
+	Name    string `json:"name" jsonschema:"Your configured name from project_setup Identity"`
+	Mode    string `json:"mode" jsonschema:"Your current mode indicator (e.g. 🐱, ✨, 🔥, 📋, 🧠, 🔬)"`
+	Type    string `json:"type" jsonschema:"The interaction type: clarification, approval, or blocker"`
+	Message string `json:"message" jsonschema:"The message to display in the notification"`
+}
+
+func runMCPServer() error {
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "cece",
+		Version: "1.0.0",
+	}, nil)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "signal_interaction",
+		Description: "Signal an interaction to the user via desktop notification. Call this when you need user input for a clarification, approval, or blocker.",
+	}, handleSignalInteraction)
+
+	slog.Debug("starting MCP server")
+	return server.Run(context.Background(), &mcp.StdioTransport{})
+}
+
+func handleSignalInteraction(ctx context.Context, req *mcp.CallToolRequest, args signalInteractionArgs) (*mcp.CallToolResult, any, error) {
+	// Map interaction type to icon
+	icon := "dialog-question"
+	if args.Type == "blocker" {
+		icon = "dialog-warning"
+	}
+
+	// Send notification
+	name := args.Name
+	if name == "" {
+		name = "CeCe"
+	}
+	title := fmt.Sprintf("%s %s", args.Mode, name)
+	cmd := exec.Command("notify-send", "-i", icon, title, args.Message)
+	if err := cmd.Run(); err != nil {
+		slog.Warn("notify-send failed", "error", err)
+		// Don't fail the tool call if notification fails
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "notification sent"},
+		},
+	}, nil, nil
+}
+
+func ensureMCPServer() error {
+	// Check if already configured
+	cmd := exec.Command("claude", "mcp", "get", "cece")
+	if err := cmd.Run(); err == nil {
+		slog.Debug("MCP server already configured")
+		return nil
+	}
+
+	// Add it
+	fmt.Printf("Configuring CeCe MCP server...\n")
+	addCmd := exec.Command("claude", "mcp", "add", "cece", "cece", "mcp")
+	if err := addCmd.Run(); err != nil {
+		return fmt.Errorf("failed to configure MCP server: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/cece/system_prompt.md
+++ b/cmd/cece/system_prompt.md
@@ -180,12 +180,34 @@ When you encounter an inline tag:
 
 1. Read the command's `<policy>` block
 2. Find the action for this interaction type
-3. Execute the action:
-   - **ask**: Display the prompt and wait for user response
+3. The text inside the tag is *guidance*, not a script. Understand its intent,
+   then express it naturally in your own words. Vary your phrasing — do not
+   repeat the same wording across interactions.
+4. Execute the action:
+   - **ask**: FIRST call `signal_interaction` with your name, mode indicator,
+     interaction type, and your rephrased prompt. THEN display the prompt (with
+     your mode indicator) and wait for user response. Never display the prompt
+     without calling `signal_interaction` first.
    - **continue**: Explain your reasoning aloud, then proceed
    - **revert**: Explain what's blocking you, undo uncommitted work, return to
      chat mode
    - **stop**: Explain why you're pausing, save progress, return to chat mode
+
+<good-example>
+Tag: <clarification>Describe the task you want to work on.</clarification>
+CeCe: ✨ What would you like to accomplish?
+</good-example>
+
+<good-example>
+Tag: <approval>Ready to post this plan?</approval>
+CeCe: 📋 Does this plan look good to you?
+</good-example>
+
+<bad-example>
+Tag: <clarification>Describe the task.</clarification>
+CeCe: ✨ Describe the task.
+(Too literal — just repeating the tag)
+</bad-example>
 
 For non-ask actions, narrate naturally before acting — like thinking aloud.
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,4 +4,5 @@
 
 - [Getting Started](./getting-started.md)
 - [Concepts](./concepts.md)
+- [Notifications](./notifications.md)
 - [Comparison](./comparison.md)

--- a/docs/src/notifications.md
+++ b/docs/src/notifications.md
@@ -1,0 +1,80 @@
+# Notifications
+
+CeCe can send desktop notifications when it needs your attention during command
+modes. This helps when you're multitasking—CeCe works autonomously, and you get
+a ping when input is needed.
+
+## How It Works
+
+When CeCe encounters an interaction pattern (clarification, approval, or
+blocker) with a policy of `ask`, it calls the `signal_interaction` MCP tool
+before displaying the prompt. This triggers a desktop notification.
+
+**Interaction types:**
+
+| Type | Icon | Meaning |
+|------|------|---------|
+| `clarification` | dialog-question | CeCe needs more information |
+| `approval` | dialog-question | CeCe needs your sign-off |
+| `blocker` | dialog-warning | CeCe cannot proceed as planned |
+
+## Requirements
+
+The notification system uses `notify-send`, which works with any
+freedesktop-compliant notification daemon.
+
+Make sure `notify-send` is installed (usually part of `libnotify`):
+
+```bash
+# Arch Linux
+pacman -S libnotify
+
+# Debian/Ubuntu
+apt install libnotify-bin
+```
+
+## MCP Server
+
+The notification feature is provided by an MCP server built into the `cece`
+binary. When you run `cece`, it automatically configures Claude Code to use this
+server.
+
+**Manual configuration** (if needed):
+
+```bash
+claude mcp add cece cece mcp
+```
+
+This tells Claude Code to spawn `cece mcp` as an MCP server.
+
+## The `signal_interaction` Tool
+
+The MCP server exposes a single tool:
+
+**Name:** `signal_interaction`
+
+**Parameters:**
+- `name` (string) — The configured name from project_setup Identity (falls back to "CeCe")
+- `mode` (string) — The current mode indicator (e.g., 🐱, ✨, 🔥)
+- `type` (string) — The interaction type: `clarification`, `approval`, or `blocker`
+- `message` (string) — The message to display in the notification
+
+**Example call:**
+
+```json
+{
+  "name": "CeCe",
+  "mode": "✨",
+  "type": "clarification",
+  "message": "Which authentication method should we use?"
+}
+```
+
+This sends a desktop notification with title "✨ CeCe" and the message as the
+body. The icon reflects the interaction type (question or warning).
+
+## Customization
+
+The notification behavior depends on your notification daemon's configuration.
+Refer to your notification daemon's documentation for customization options
+(positioning, styling, timeouts, etc.).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/lthms/cece
 
-go 1.21
+go 1.23.0
+
+require github.com/modelcontextprotocol/go-sdk v1.2.0
+
+require (
+	github.com/google/jsonschema-go v0.3.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
+github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=


### PR DESCRIPTION
## Summary

- Add `cece mcp` subcommand that runs an MCP server with `signal_interaction` tool
- Auto-configure the MCP server in Claude Code settings on first run
- Update system prompt to call `signal_interaction` on `ask` interactions
- Add documentation for the notification system

## Test plan

1. Run `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}' | cece mcp` and verify valid JSON-RPC response
2. Run `cece` on a fresh environment (no MCP configured) and verify "Configuring CeCe MCP server..." appears
3. Invoke `/cece:scope` (which has `ask` policy) and verify desktop notification fires when clarification is asked
4. Verify notification icon is `dialog-question` for clarification/approval, `dialog-warning` for blocker

Fixes #66