### PR TITLE
Add GitLab MR interaction skill

### DIFF
--- a/plugins/cece/skills/gitlab/SKILL.md
+++ b/plugins/cece/skills/gitlab/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gitlab
 description: >
-  Required skill to interact with GitLab. Includes glab CLI commands
-  for MR operations, discussion threads, and CI pipelines.
+  Required skill to perform GitLab MR operations, manage discussion
+  threads, and check CI pipeline status using the glab CLI.
 user-invocable: false
 ---
 
@@ -52,8 +52,8 @@ glab mr view <mr-iid> --comments
 
 <action name="discussions">
 
-The `glab mr note` command only creates top-level comments. To reply in
-existing threads, use `glab api` instead.
+`glab mr note` creates top-level comments only. Use `glab api` to reply in
+existing threads.
 
 <action name="top-level-comment">
 
@@ -84,12 +84,12 @@ glab api --method POST \
 
 Replace `<discussion_id>` with the discussion's `id` from the listing above.
 
-</action>
-
 <constraint>
 Thread resolution triggers GitLab workflows and notifications. Only users
 should resolve threads — NEVER resolve them programmatically.
 </constraint>
+
+</action>
 
 </action>
 

--- a/plugins/cece/skills/gitlab/SKILL.md
+++ b/plugins/cece/skills/gitlab/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gitlab
+description: >
+  Required skill to interact with GitLab. Includes glab CLI commands
+  for MR operations, discussion threads, and CI pipelines.
+user-invocable: false
+---
+
+# GitLab MR Interactions
+
+Concrete `glab` commands for common GitLab merge request operations.
+
+Note: `:fullpath` is a `glab api` placeholder that resolves to the current
+project's full path (e.g., `group/project`). Other placeholders like
+`<mr-iid>` are literal values you supply.
+
+<action name="create-mr">
+
+```bash
+glab mr create --title "<title>" --target-branch <target> --description "<body>"
+```
+
+Omit `--target-branch` to target the repository's default branch.
+
+</action>
+
+<action name="update-mr">
+
+Change the target branch:
+
+```bash
+glab mr update <mr-iid> --target-branch <new-target>
+```
+
+Update title or description:
+
+```bash
+glab mr update <mr-iid> --title "<new-title>"
+glab mr update <mr-iid> --description "<new-description>"
+```
+
+</action>
+
+<action name="view-mr">
+
+```bash
+glab mr view <mr-iid>
+glab mr view <mr-iid> --comments
+```
+
+</action>
+
+<action name="discussions">
+
+The `glab mr note` command only creates top-level comments. To reply in
+existing threads, use `glab api` instead.
+
+<action name="top-level-comment">
+
+```bash
+glab mr note <mr-iid> -m "<message>"
+```
+
+</action>
+
+<action name="list-discussions">
+
+```bash
+glab api projects/:fullpath/merge_requests/<mr-iid>/discussions
+```
+
+This returns a JSON array. Each discussion has an `id` field (the
+`discussion_id`) and a `notes` array containing the individual comments.
+
+</action>
+
+<action name="reply-in-thread">
+
+```bash
+glab api --method POST \
+  "projects/:fullpath/merge_requests/<mr-iid>/discussions/<discussion_id>/notes" \
+  -f body="<reply text>"
+```
+
+Replace `<discussion_id>` with the discussion's `id` from the listing above.
+
+</action>
+
+<constraint>
+Thread resolution triggers GitLab workflows and notifications. Only users
+should resolve threads — NEVER resolve them programmatically.
+</constraint>
+
+</action>
+
+<action name="ci-pipelines">
+
+<action name="pipeline-status">
+
+```bash
+glab ci status
+glab ci status --branch <branch>
+```
+
+</action>
+
+<action name="job-logs">
+
+By job name:
+
+```bash
+glab ci trace <job-name>
+glab ci trace <job-name> --branch <branch>
+```
+
+By pipeline ID:
+
+```bash
+glab ci trace --pipeline-id <id> <job-name>
+```
+
+</action>
+
+<action name="list-jobs">
+
+```bash
+glab ci list
+glab ci list --branch <branch>
+```
+
+</action>
+
+</action>


### PR DESCRIPTION
## Summary

- Add `plugins/cece/skills/gitlab/SKILL.md` as background knowledge for GitLab MR interactions
- Encodes concrete `glab` CLI patterns for MR creation, target branch updates, discussion thread replies, pipeline status, and job failure logs
- Uses `glab api` for threaded discussion replies (not supported by `glab mr note`)

Fixes #69